### PR TITLE
ci(blocklist-sync): scheduled weekly mirror refresh + safety gates

### DIFF
--- a/.github/workflows/blocklist-sync.yml
+++ b/.github/workflows/blocklist-sync.yml
@@ -1,0 +1,300 @@
+name: Blocklist sync
+
+# Weekly mirror refresh. Runs `make sync` on a fresh checkout, opens a PR
+# with the diff, runs deterministic gates (path allowlist, new-file
+# detector, per-list size deltas, format check on changed lines), and
+# auto-merges only when every gate passes. Modelled on the dependabot
+# auto-merge pattern but without an LLM step — blocklist diffs are
+# multi-MB and an LLM review buys nothing here.
+#
+# Kill-switch: set the repo variable BLOCKLIST_SYNC_AUTOMERGE_PAUSED to
+# 'true' to keep the PR open without merging.
+
+on:
+  schedule:
+    # Monday 06:00 UTC = 07:00 CET / 08:00 CEST. Early Monday morning
+    # Europe time, so a human is awake and online when the run lands.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: blocklist-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.BLOKADA_APP_ID }}
+          private-key: ${{ secrets.BLOKADA_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_USER: blokada-ci-checkout[bot]
+        run: |
+          set -euo pipefail
+          gh_user_id=$(gh api "/users/${APP_USER}" --jq .id)
+          git config user.name "${APP_USER}"
+          git config user.email "${gh_user_id}+${APP_USER}@users.noreply.github.com"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Run sync (SKIP_COMMIT=1)
+        # The sync orchestrator pulls fresh tracker-radar, regenerates
+        # ddg/exodus blocklists, and runs mirror.py against all upstream
+        # sources. SKIP_COMMIT=1 stops it from creating a local commit so
+        # CI can stage the diff itself.
+        env:
+          SKIP_COMMIT: '1'
+        working-directory: scripts
+        run: |
+          set -euo pipefail
+          make sync
+
+      - name: Check for changes
+        id: changes
+        run: |
+          set -euo pipefail
+          if git diff --quiet HEAD && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No upstream changes — exiting cleanly."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run gates
+        id: gates
+        if: steps.changes.outputs.has_changes == 'true'
+        # Gates compare the working tree vs HEAD (the unmodified main commit
+        # just checked out). G1 (make test) is invoked via the `gates`
+        # Makefile target's dependency. The step always exits 0 — a failed
+        # gate sets verdict=FAIL so later steps still open the PR with a
+        # `needs-review` label and the reason as a PR comment.
+        working-directory: scripts
+        run: |
+          set +e
+          make gates 2>&1 | tee /tmp/gates.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "verdict=PASS" >> "$GITHUB_OUTPUT"
+            echo "reason=all gates passed" >> "$GITHUB_OUTPUT"
+          else
+            # Capture the first `Gn FAIL: ...` header plus its indented
+            # detail lines. Without the detail lines, the reason in the
+            # PR body is just "G2 FAIL: changed paths outside allowlist:"
+            # with no indication of which paths.
+            reason=$(awk '/FAIL/{found=1; print; next} found && /^  /{print; next} found{exit}' /tmp/gates.log)
+            [ -z "$reason" ] && reason="gate failure (rc=$rc) — see workflow logs"
+            echo "verdict=FAIL" >> "$GITHUB_OUTPUT"
+            {
+              echo 'reason<<BLOCKLIST_SYNC_REASON_EOF'
+              echo "$reason"
+              echo 'BLOCKLIST_SYNC_REASON_EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR body
+        id: body
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          VERDICT: ${{ steps.gates.outputs.verdict }}
+          REASON: ${{ steps.gates.outputs.reason }}
+        # Public-repo safe: no GCP project names, no private repo names,
+        # no internal trigger or topic names. Per-file line-count delta
+        # only.
+        run: |
+          set -euo pipefail
+          today=$(date -u +%Y-%m-%d)
+          {
+            echo "Automated weekly mirror refresh ($today)."
+            echo
+            echo "## Gates"
+            echo
+            if [ "${VERDICT}" = "PASS" ]; then
+              echo ":white_check_mark: All gates passed — eligible for auto-merge."
+            else
+              echo ":warning: Gate tripped — needs human review."
+              echo
+              echo '```'
+              echo "${REASON}"
+              echo '```'
+            fi
+            echo
+            echo "## File deltas"
+            echo
+            echo "| File | Before (lines) | After (lines) | Change |"
+            echo "|---|---:|---:|---:|"
+            git diff --name-only HEAD -- 'mirror/v5/' 'blocklists/' \
+              | head -200 \
+              | while IFS= read -r f; do
+                  pre=$(git show "HEAD:$f" 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+                  if [ -f "$f" ]; then
+                    post=$(wc -l < "$f" | tr -d ' ')
+                  else
+                    post=0
+                  fi
+                  if [ "$pre" -gt 0 ]; then
+                    pct=$(awk -v a="$pre" -v b="$post" 'BEGIN{printf "%+.1f%%", 100*(b-a)/a}')
+                  else
+                    pct="—"
+                  fi
+                  echo "| \`$f\` | $pre | $post | $pct |"
+                done
+            untracked=$(git ls-files --others --exclude-standard | grep -E '^(mirror/v5/|blocklists/)' || true)
+            if [ -n "$untracked" ]; then
+              echo
+              echo "## New files"
+              echo
+              # Loop, not unquoted expansion — real mirror paths can contain
+              # spaces (e.g. `1hosts/pro (wildcards)/hosts.txt`).
+              printf '%s\n' "$untracked" | while IFS= read -r f; do
+                printf -- '- `%s`\n' "$f"
+              done
+            fi
+          } > /tmp/pr-body.md
+          {
+            echo 'body<<BLOCKLIST_SYNC_BODY_EOF'
+            cat /tmp/pr-body.md
+            echo 'BLOCKLIST_SYNC_BODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Push branch
+        id: push
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          today=$(date -u +%Y-%m-%d)
+          branch="automation/blocklist-sync/${today}"
+          # If a previous run on the same day left a branch, tack on a run
+          # suffix so we don't trample its PR.
+          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            branch="${branch}-${{ github.run_id }}"
+          fi
+          git switch -c "${branch}"
+          git add -A
+          git commit -m "Sync mirrors (${today})"
+          git push origin "${branch}"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR
+        id: pr
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ steps.push.outputs.branch }}
+          BODY: ${{ steps.body.outputs.body }}
+        run: |
+          set -euo pipefail
+          today=$(date -u +%Y-%m-%d)
+
+          # Close any stale open sync PR before opening this run's PR.
+          # Without this, an unattended needs-review PR from a past run
+          # would accumulate alongside each new weekly run. Match by
+          # branch-name prefix (authoritative — humans cannot silently
+          # rename it) rather than by label, since this repo intentionally
+          # does not maintain a sync-specific label set.
+          old_prs=$(gh pr list --repo "$REPO" --state open \
+            --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("automation/blocklist-sync/")) | .number')
+          for pr in $old_prs; do
+            gh pr close "$pr" --repo "$REPO" --delete-branch \
+              --comment "Superseded by today's sync run." || true
+          done
+
+          pr_url=$(gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "Sync mirrors (${today})" \
+            --body "${BODY}")
+          echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
+          pr_number=$(echo "${pr_url}" | sed -E 's|.*/pull/([0-9]+).*|\1|')
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify PR head unchanged before merge
+        # Defence in depth: the workflow on main is the only writer to this
+        # branch in the normal flow, so the race window is small. This check
+        # catches the rare case where an operator pushed an extra commit to
+        # the bot branch between PR creation and merge — refusing to merge
+        # is preferable to squashing the operator's edit unreviewed.
+        id: stale-check
+        if: >-
+          steps.changes.outputs.has_changes == 'true' &&
+          steps.gates.outputs.verdict == 'PASS' &&
+          vars.BLOCKLIST_SYNC_AUTOMERGE_PAUSED != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.pr.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+          PUSHED_HEAD: ${{ steps.push.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          current=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
+          if [ "$current" != "$PUSHED_HEAD" ]; then
+            echo "PR head ($current) differs from pushed head ($PUSHED_HEAD); refusing stale merge"
+            exit 1
+          fi
+          echo "PR head matches pushed SHA: $PUSHED_HEAD"
+
+      - name: Squash-merge
+        if: >-
+          steps.changes.outputs.has_changes == 'true' &&
+          steps.gates.outputs.verdict == 'PASS' &&
+          vars.BLOCKLIST_SYNC_AUTOMERGE_PAUSED != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.pr.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr review "$PR" --repo "$REPO" \
+            --approve \
+            --body "Auto-approved: all gates passed."
+          gh pr merge "$PR" --repo "$REPO" --squash --delete-branch
+
+      - name: Summary
+        if: always()
+        env:
+          HAS_CHANGES: ${{ steps.changes.outputs.has_changes }}
+          VERDICT: ${{ steps.gates.outputs.verdict }}
+          REASON: ${{ steps.gates.outputs.reason }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+          KILL_SWITCH: ${{ vars.BLOCKLIST_SYNC_AUTOMERGE_PAUSED }}
+        run: |
+          {
+            if [ "${HAS_CHANGES}" != "true" ]; then
+              echo "### No upstream changes"
+            else
+              echo "### Sync run"
+              echo
+              echo "- PR: ${PR_URL}"
+              echo "- Gate verdict: \`${VERDICT}\`"
+              echo "- Reason: ${REASON}"
+              echo "- Kill-switch (BLOCKLIST_SYNC_AUTOMERGE_PAUSED): \`${KILL_SWITCH:-unset}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test gen-whitelist sync
+.PHONY: test gen-whitelist sync gates
 
 # Run whitelist filter tests
 test:
@@ -13,3 +13,13 @@ gen-whitelist:
 # Sync mirrors (depends on tests passing and updated whitelist)
 sync: test gen-whitelist
 	./sync-mirrors.sh
+
+# Run safety gates against the working tree vs HEAD. Used by CI before
+# auto-merging a sync PR; safe to run locally too (e.g. after
+# `SKIP_COMMIT=1 make sync` to inspect what would land).
+gates: test
+	./gates/check_paths.sh
+	./gates/check_new_files.sh
+	python3 ./gates/check_size_deltas.py
+	python3 ./gates/check_format.py
+	@echo "All gates passed."

--- a/scripts/gates/check_format.py
+++ b/scripts/gates/check_format.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Gate G5 — format check on changed lines.
+
+Tampering tripwire. Each added line in a mirror/v5/ or blocklists/ file must
+be either blank, a comment, or a recognised host-list entry: bounded length,
+no HTML/JS markers. A compromised upstream that started serving HTML or JS
+in its hosts.txt would fail here even if size deltas looked normal.
+
+The rules are intentionally public: the strength of this gate comes from
+enforcement (the workflow on main is the only writer; a fork edit cannot
+bypass it), not from hiding the rules. Treat this file like any other piece
+of public infrastructure code.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+ALLOWED_PREFIXES = ("mirror/v5/", "blocklists/")
+MAX_LEN = 256
+MAX_FAILURES_REPORTED = 20
+
+# Recognised host-list entry shapes. Listed broadest-first; each pattern
+# anchors with ^/$ so they only match a complete line.
+HOST_PATTERNS = (
+    # IPv4/IPv6 prefix (with optional zone identifier) + hostname.
+    # Covers `0.0.0.0 host`, `127.0.0.1 host`, `255.255.255.255 host`,
+    # `::1 host`, `ff02::3 host`, `fe80::1%lo0 host` — all of which appear
+    # in real upstream output (1hosts /etc/hosts boilerplate).
+    re.compile(r"^[0-9a-fA-F:.]+(?:%[A-Za-z0-9]+)?\s+(?:\*\.)?[A-Za-z0-9_][A-Za-z0-9_.\-]*$"),
+    # Bare hostname / wildcard (ddgtrackerradar, exodusprivacy).
+    re.compile(r"^(?:\*\.)?[A-Za-z0-9_][A-Za-z0-9_.\-]*$"),
+    # Adblock Plus basic syntax `||domain^` (1hosts wildcards, oisd).
+    # Modifiers like `$third-party`, `domain=`, `@@||allowlist^` are
+    # intentionally rejected — they don't appear in current upstream
+    # output and adding them would expand the parse surface for tampering.
+    re.compile(r"^\|\|[A-Za-z0-9_][A-Za-z0-9_.\-]*\^$"),
+)
+COMMENT_RE = re.compile(r"^\s*[#!;]")
+BLANK_RE = re.compile(r"^\s*$")
+TAMPER_MARKERS = (
+    # Each marker contains a character that does NOT appear in any valid
+    # host-list entry (no `<`, `>`, `(`, `:` in `HOST_PATTERNS`), so these
+    # cannot match a benign hostname. Bare alphabetic tokens like
+    # "script" or "function" are intentionally NOT listed: they collide
+    # with real upstream domains (e.g. `script.example.com`,
+    # `scripts.clarity.ms`, `function.tracker.com`) and would block
+    # auto-merge on legitimate data. HTML/JS injection still gets
+    # caught via `<` / `>` / `eval(` / `javascript:` and via the
+    # HOST_PATTERNS regex rejecting any line shaped like code.
+    "<", ">",
+    "eval(", "javascript:",
+    "<!doctype", "<html", "<?xml",
+)
+
+
+def run(*args: str) -> str:
+    return subprocess.check_output(args, text=True)
+
+
+def main() -> int:
+    # Resolve repo root so the pathspecs below match regardless of caller
+    # cwd. The Makefile invokes us from `scripts/`, so a bare `git diff
+    # -- mirror/v5/ blocklists/` would silently match zero files and the
+    # gate would pass on everything (including tampering).
+    root = run("git", "rev-parse", "--show-toplevel").strip()
+    diff = run(
+        "git", "-C", root, "diff", "--unified=0", "HEAD", "--",
+        *ALLOWED_PREFIXES,
+    )
+    current_path: str | None = None
+    failures: list[str] = []
+    checked = 0
+
+    for raw in diff.splitlines():
+        # File header: capture the post-image path. Some git versions append
+        # mode/timestamp info after a tab — strip it.
+        if raw.startswith("+++ b/"):
+            current_path = raw[len("+++ b/"):].split("\t", 1)[0]
+            continue
+        if raw.startswith("--- ") or raw.startswith("@@") or raw.startswith("diff --git"):
+            continue
+        if not raw.startswith("+"):
+            continue
+
+        line = raw[1:]
+        if BLANK_RE.match(line) or COMMENT_RE.match(line):
+            continue
+        checked += 1
+
+        if len(line) > MAX_LEN:
+            failures.append(
+                f"{current_path}: line >{MAX_LEN} chars: {line[:80]!r}..."
+            )
+            continue
+
+        low = line.lower()
+        marker_hit = next((m for m in TAMPER_MARKERS if m in low), None)
+        if marker_hit:
+            failures.append(
+                f"{current_path}: contains tamper marker {marker_hit!r}: {line[:80]!r}"
+            )
+            continue
+
+        if not any(p.match(line) for p in HOST_PATTERNS):
+            failures.append(
+                f"{current_path}: not a recognised host-list entry: {line[:80]!r}"
+            )
+
+    if failures:
+        print("G5 FAIL: format check tripped on changed lines:", file=sys.stderr)
+        for f in failures[:MAX_FAILURES_REPORTED]:
+            print(f"  {f}", file=sys.stderr)
+        if len(failures) > MAX_FAILURES_REPORTED:
+            print(f"  ... and {len(failures)-MAX_FAILURES_REPORTED} more", file=sys.stderr)
+        return 5
+
+    print(f"G5 OK: {checked} added content lines passed format check")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gates/check_new_files.sh
+++ b/scripts/gates/check_new_files.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Gate G3 — new-file detector.
+# mirror.py cannot add new lists without a code change; ddg.py and exodus.py
+# can produce new files when upstream metadata changes. Either way, a new
+# list deserves a deliberate human look — fail the gate so the PR stays
+# open for review rather than auto-merging a structural addition.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+untracked=$(git ls-files --others --exclude-standard | sed '/^[[:space:]]*$/d')
+
+if [ -z "$untracked" ]; then
+  echo "G3 OK: no new files"
+  exit 0
+fi
+
+echo "G3 FAIL: new file(s) added (require human review):" >&2
+printf '%s\n' "$untracked" | sed 's/^/  /' >&2
+exit 3

--- a/scripts/gates/check_paths.sh
+++ b/scripts/gates/check_paths.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Gate G2 — path allowlist.
+# Every changed/added file must be under mirror/v5/, blocklists/, the
+# regenerated whitelist files, or the tracker-radar submodule pointer.
+# Anything else (e.g. mirror.py, whitelist-manual, top-level files) trips
+# the gate so a human reviews the structural change instead of letting it
+# ride in on a sync PR. Rules are intentionally public: the strength of
+# the gate comes from enforcement (the workflow on main is the only writer
+# and squash-merges only via the App token), not from hiding them.
+
+set -euo pipefail
+
+ALLOW='^(mirror/v5/|blocklists/|scripts/whitelist$|scripts/whitelist-subdomains$|tracker-radar$)'
+
+cd "$(git rev-parse --show-toplevel)"
+
+modified=$(git diff --name-only HEAD || true)
+untracked=$(git ls-files --others --exclude-standard || true)
+all=$(printf '%s\n%s\n' "$modified" "$untracked" | sed '/^[[:space:]]*$/d' | sort -u)
+
+if [ -z "$all" ]; then
+  echo "G2 OK: no file changes"
+  exit 0
+fi
+
+violations=$(printf '%s\n' "$all" | grep -Ev "$ALLOW" || true)
+if [ -n "$violations" ]; then
+  echo "G2 FAIL: changed paths outside allowlist:" >&2
+  printf '%s\n' "$violations" | sed 's/^/  /' >&2
+  exit 2
+fi
+
+count=$(printf '%s\n' "$all" | wc -l | tr -d ' ')
+echo "G2 OK: $count changed paths within allowlist"

--- a/scripts/gates/check_size_deltas.py
+++ b/scripts/gates/check_size_deltas.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Gate G4 — per-list size delta thresholds.
+
+For every modified file under mirror/v5/ or blocklists/, compare line count
+in HEAD (the pre-sync state) vs the current working copy. Trips the gate if
+the new file dropped more than 20% of its lines (likely a partially-broken
+upstream feed) or grew to more than 10x its previous size (likely an upstream
+that started spamming or got compromised).
+
+Thresholds are intentionally public: the strength of this gate comes from
+enforcement, not from hiding the rules.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+DROP_RATIO = 0.8       # post must be >= 80% of pre
+GROWTH_RATIO = 10      # post must be <= 10x pre
+ALLOWED_PREFIXES = ("mirror/v5/", "blocklists/")
+
+
+def run(*args: str) -> str:
+    return subprocess.check_output(args, text=True)
+
+
+def repo_root() -> Path:
+    return Path(run("git", "rev-parse", "--show-toplevel").strip())
+
+
+def main() -> int:
+    root = repo_root()
+    modified = run("git", "-C", str(root), "diff", "--name-only", "HEAD").splitlines()
+    targets = [p for p in modified if p.startswith(ALLOWED_PREFIXES)]
+    if not targets:
+        print("G4 OK: no modified mirror/blocklist files")
+        return 0
+
+    failures: list[str] = []
+    for path in targets:
+        try:
+            pre_blob = subprocess.check_output(
+                ["git", "-C", str(root), "show", f"HEAD:{path}"],
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError:
+            continue
+        pre = pre_blob.count(b"\n")
+
+        full = root / path
+        if not full.exists():
+            failures.append(f"{path}: deleted entirely (was {pre} lines)")
+            continue
+        post = full.read_bytes().count(b"\n")
+
+        if pre == 0:
+            continue
+
+        if post < pre * DROP_RATIO:
+            failures.append(
+                f"{path}: line count dropped from {pre} to {post} "
+                f"({100*(1-post/pre):.0f}% drop, threshold 20%)"
+            )
+        elif post > pre * GROWTH_RATIO:
+            failures.append(
+                f"{path}: line count grew from {pre} to {post} "
+                f"({post/pre:.1f}x, threshold 10x)"
+            )
+
+    if failures:
+        print("G4 FAIL: size delta thresholds tripped:", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        return 4
+
+    print(f"G4 OK: {len(targets)} files within size-delta thresholds")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync-mirrors.sh
+++ b/scripts/sync-mirrors.sh
@@ -12,7 +12,9 @@ cd ../scripts
 ./mirror.py
 
 cd ..
-git add .
-git commit -am "Sync mirrors"
+if [ "${SKIP_COMMIT:-0}" != "1" ]; then
+  git add .
+  git commit -am "Sync mirrors"
+fi
 
 echo "Done"


### PR DESCRIPTION
## Summary

Replaces the manual `make sync` + commit-to-master flow with a scheduled GitHub Actions workflow that opens a PR, runs deterministic gates, and auto-merges only when every gate passes — modelled on the `dependabot-auto-merge` pattern but without an LLM step (multi-MB blocklist diffs make narrative review pointless).

Closes the work tracked in `blokadaorg/issue-tracker` issue #282.

- **`.github/workflows/blocklist-sync.yml`** — single-job workflow, cron `0 6 * * 1` (Monday 06:00 UTC ≈ 07:00 CET / 08:00 CEST, early Monday morning Europe time so a human is awake) plus `workflow_dispatch`. Mints a `blokada-ci-checkout` App token, runs `make sync` with `SKIP_COMMIT=1`, opens a sync PR with a per-file line-count delta table, squash-merges only when all gates pass and `BLOCKLIST_SYNC_AUTOMERGE_PAUSED` is unset. No labels are created — the branch prefix `automation/blocklist-sync/*` and the explicit verdict header in the PR body are the discoverable signals.
- **`scripts/gates/`** — four deterministic gates, each in its own script so failures name the offending gate by number:
  - **G2** path allowlist: only `mirror/v5/**`, `blocklists/**`, `scripts/whitelist`, `scripts/whitelist-subdomains`, `tracker-radar` may change. `mirror.py` edits or whitelist-input edits don't ride in.
  - **G3** new-file detector: any newly added file fails the gate. `mirror.py` cannot add new lists without a code change; `ddg.py` / `exodus.py` can produce new files when upstream metadata changes — either way a new list deserves human review.
  - **G4** size delta thresholds per file: >20% line drop or >10x line growth fails. Catches partial upstream feeds and runaway upstreams.
  - **G5** format check on changed lines: each added line must be a host file entry (`0.0.0.0 host`, `127.0.0.1 host`, IPv6 `::1 / fe80::%lo / ff00::0`, broadcast), a bare hostname / wildcard, or basic Adblock `||domain^`. Rejects HTML/JS markers, URL paths, Adblock modifiers (`\$third-party`, `domain=`, `@@||`). Tampering tripwire — a compromised upstream serving HTML/JS would fail here even if size deltas looked normal.
- **`scripts/Makefile`** gains a `gates` target that runs G1 (existing whitelist tests) + G2–G5 in order. Same target works locally and in CI.
- **`scripts/sync-mirrors.sh`** — the trailing `git add . && git commit -am "Sync mirrors"` is now wrapped in `if [ \"\${SKIP_COMMIT:-0}\" != \"1\" ]; then ... fi`. The manual local flow (Kar's `make sync`) is unchanged; CI runs the same orchestrator without the side effect.

Gate rules are intentionally public. The strength comes from enforcement (the workflow on `master` is the only writer; the GitHub App is the only token authorised to push and squash-merge), not from hiding the rules.

## Test plan

- [ ] After merge: `BLOKADA_APP_ID` + `BLOKADA_APP_PRIVATE_KEY` Repository secrets and `BLOCKLIST_SYNC_AUTOMERGE_PAUSED=false` Repository variable are visible under Settings → Secrets and variables → Actions (provisioned by the ops PR that landed earlier).
- [ ] `blokada-ci-checkout` GitHub App is installed on this repo with `contents: write` + `pull-requests: write` (one-time UI step).
- [ ] Trigger first run: Actions → \"Blocklist sync\" → Run workflow → branch `master`. Expect a branch `automation/blocklist-sync/<today>` and a PR titled `Sync mirrors (<today>)`.
- [ ] Inspect workflow logs: G1–G5 each emit a status line (`Gn OK` / `Gn FAIL`).
- [ ] If gates pass, watch the PR auto-squash-merge within ~1 min of the gates step completing. Branch is deleted.
- [ ] If gates trip on the first real run, observe that the PR stays open with the gate's reason in the body and as a workflow step summary.
- [ ] Local sanity: `cd scripts && SKIP_COMMIT=1 make sync && make gates` succeeds against a clean fresh clone.

## Downstream chain validation (separate from this PR)

After the auto-merge in the test plan completes, the existing `buildlists` → Pub/Sub → blockarust → ops auto-PR chain should fire as it does today when Kar manually commits a sync. That chain isn't touched by this PR — confirming it still triggers under bot authorship is part of validation.