### PR TITLE
ci(blocklist-sync): shallow parent checkout

### DIFF
--- a/.github/workflows/blocklist-sync.yml
+++ b/.github/workflows/blocklist-sync.yml
@@ -38,12 +38,17 @@ jobs:
           private-key: ${{ secrets.BLOKADA_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - name: Checkout main
+      - name: Checkout master
         uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
-          fetch-depth: 0
+          # Default fetch-depth: 1 (shallow). Sync commits churn ~1M+
+          # lines each and the repo has accumulated many — full history
+          # is gigabytes. Nothing in the workflow needs more than HEAD:
+          # G2/G3/G5 use `git diff HEAD`, G4 uses `git show HEAD:path`,
+          # `make sync` does not walk parent history, and the new
+          # branch is created fresh off HEAD with no rebase.
 
       - name: Configure git identity
         env:


### PR DESCRIPTION
Follow-up to #11. The first `workflow_dispatch` of the new sync workflow stalled in the checkout step — `fetch-depth: 0` was pulling the entire blocklist history, and individual sync commits churn ~1M+ lines each across many commits, so the parent clone is in the gigabyte range.

Nothing in the workflow needs more than HEAD:
- **G2 / G3 / G5** diff against HEAD (`git diff HEAD`, `git ls-files --others`)
- **G4** reads HEAD blobs via `git show HEAD:<path>`
- `make sync` regenerates working-tree files; never walks parent history
- The auto-generated branch is created fresh off HEAD with no rebase

Drop the explicit `fetch-depth: 0` and let `actions/checkout` use its `fetch-depth: 1` default. Submodule clone (tracker-radar) stays recursive; its history is much smaller and not the cause of the slowdown.

## Test plan

- [ ] After merge: `workflow_dispatch` the workflow against `master`. Checkout step should complete in well under a minute.
- [ ] Sync step proceeds, gates run, PR opens, auto-merges if gates pass.
- [ ] Downstream chain (buildlists → Pub/Sub → blockarust → ops PR) fires as before.