### PR TITLE
ci(blocklist-sync): derive bot git identity from app-slug, handle non-public bot user

### DIFF
--- a/.github/workflows/blocklist-sync.yml
+++ b/.github/workflows/blocklist-sync.yml
@@ -53,12 +53,25 @@ jobs:
       - name: Configure git identity
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_USER: blokada-ci-checkout[bot]
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
-          gh_user_id=$(gh api "/users/${APP_USER}" --jq .id)
-          git config user.name "${APP_USER}"
-          git config user.email "${gh_user_id}+${APP_USER}@users.noreply.github.com"
+          # Derive identity from the App's slug (output by
+          # actions/create-github-app-token). Some Apps' bot users aren't
+          # exposed via /users/<slug>%5Bbot%5D — the request returns 404
+          # even though the bot exists and can author commits — so the
+          # numeric-ID lookup is best-effort. If it fails, fall back to
+          # the slug-only noreply format; git accepts it and GitHub still
+          # attributes the commit to the bot via the username portion.
+          name="${APP_SLUG}[bot]"
+          if id=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id 2>/dev/null); then
+            email="${id}+${name}@users.noreply.github.com"
+          else
+            email="${name}@users.noreply.github.com"
+          fi
+          git config user.name  "${name}"
+          git config user.email "${email}"
+          echo "Configured: ${name} <${email}>"
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Follow-up to #11 / #12. The first dispatch after the shallow-checkout fix tripped on the **Configure git identity** step:

```
gh: Not Found (HTTP 404)
##[error]Process completed with exit code 1.
```

Diagnosis: `gh api /users/blokada-ci-checkout[bot]` returns 404 (verified locally with both bare and URL-encoded brackets). Comparable lookup `gh api /users/dependabot[bot]` resolves cleanly. The App's bot user is apparently internal — its `[bot]` user is not exposed via `/users/`, even though the bot exists and can author commits.

## Fix

- Drive the identity from `actions/create-github-app-token`'s `app-slug` output instead of hardcoding `blokada-ci-checkout[bot]`.
- URL-encode `[bot]` (`%5Bbot%5D`) when calling the user lookup.
- Treat the numeric-ID lookup as best-effort: on 404, fall back to the slug-only noreply email (`<slug>[bot]@users.noreply.github.com`). Git accepts it and GitHub still attributes the commit to the bot via the username portion.

## Test plan

- [ ] After merge: `workflow_dispatch` the workflow against `master`.
- [ ] Configure git identity step succeeds and prints `Configured: <slug>[bot] <email>`.
- [ ] Subsequent steps run (sync → gates → PR open → auto-merge if gates pass).
- [ ] Sync PR commit author is recorded as the bot.