### PR TITLE
ci(blocklist-sync): fix PR base + migrate to client-id input

### DIFF
--- a/.github/workflows/blocklist-sync.yml
+++ b/.github/workflows/blocklist-sync.yml
@@ -34,7 +34,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BLOKADA_APP_ID }}
+          # Use the client-id input — `app-id` is deprecated in v3.
+          # Requires `BLOKADA_APP_CLIENT_ID` secret distributed by
+          # ops/secrets.tf alongside the legacy `BLOKADA_APP_ID`.
+          client-id: ${{ secrets.BLOKADA_APP_CLIENT_ID }}
           private-key: ${{ secrets.BLOKADA_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -245,8 +248,11 @@ jobs:
               --comment "Superseded by today's sync run." || true
           done
 
+          # Detect default branch at runtime (this repo uses `master`,
+          # which differs from many GitHub repos that use `main`).
+          default_branch=$(gh repo view "$REPO" --json defaultBranchRef --jq .defaultBranchRef.name)
           pr_url=$(gh pr create \
-            --base main \
+            --base "${default_branch}" \
             --head "${BRANCH}" \
             --title "Sync mirrors (${today})" \
             --body "${BODY}")


### PR DESCRIPTION
Follow-up to #11 / #12 / #13. Two fixes:

## 1. PR base — `main` → default-branch detection (blocker)

Run [25166458996](https://github.com/blokadaorg/landing-github-pages/actions/runs/25166458996) failed at the Open PR step with:

```
pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank,
No commits between main and automation/blocklist-sync/2026-04-30,
Base ref must be a branch (createPullRequest)
```

I'd hardcoded `--base main`, but this repo's default branch is `master`. The diff itself was correct — gates passed in 1 second, the table in the (would-be) PR body shows real changes (e.g. urlhaus +94%, phishingarmy −7%, stevenblack +2.6%). Just the wrong base.

Read the default branch at runtime from `gh repo view --json defaultBranchRef` so the workflow stays portable.

## 2. `app-id` → `client-id` (deprecation warning)

`actions/create-github-app-token@v3` emits:

```
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

Switch to `client-id`. Requires `BLOKADA_APP_CLIENT_ID` distributed by [blokadaorg/ops#3](https://github.com/blokadaorg/ops/pull/3) — that PR must land + `terraform apply` before merging this one, otherwise `Mint App token` will fail with an empty secret.

## Test plan

- [ ] Land ops PR #3, run `terraform apply`. Verify `BLOKADA_APP_CLIENT_ID` appears in the repo's Settings → Secrets and variables.
- [ ] Merge this PR.
- [ ] `workflow_dispatch` the workflow against `master`. Mint App token uses the new `client-id` input, no deprecation warning. Open PR step uses `master` as base. Sync PR opens, gates pass, auto-merges.
- [ ] Watch the downstream chain (buildlists → Pub/Sub → blockarust → ops PR).