### PR TITLE
ci(blocklist-sync): drop self-approve before merge

### DIFF
--- a/.github/workflows/blocklist-sync.yml
+++ b/.github/workflows/blocklist-sync.yml
@@ -296,9 +296,10 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh pr review "$PR" --repo "$REPO" \
-            --approve \
-            --body "Auto-approved: all gates passed."
+          # No `gh pr review --approve`: GitHub forbids an account from
+          # approving its own PR, and this App both opens and merges these
+          # PRs. `master` is not protected, so the merge does not require
+          # an approving review anyway.
           gh pr merge "$PR" --repo "$REPO" --squash --delete-branch
 
       - name: Summary


### PR DESCRIPTION
## What

Remove the `gh pr review --approve` call from the `Squash-merge` step in `.github/workflows/blocklist-sync.yml`. The step now goes straight to `gh pr merge --squash --delete-branch`.

## Why

The first run that actually exercised the auto-merge path (run [25308367362](https://github.com/blokadaorg/landing-github-pages/actions/runs/25308367362), opening PR #16) failed with:

```
failed to create review: GraphQL: Review Can not approve your own pull request (addPullRequestReview)
```

GitHub forbids any account — including a GitHub App — from approving a PR it authored. The previous run that merged PR #15 only "succeeded" because `BLOCKLIST_SYNC_AUTOMERGE_PAUSED` was set, both pre-merge steps were skipped, and the PR was merged manually by the operator.

`master` is unprotected (no branch protection rule, no ruleset), so `gh pr merge --squash` does not require an approving review. The approve call is purely dead-code that blocks the workflow.

## Validation plan

After merge: re-run the `Blocklist sync` workflow against PR #16's content and confirm the new PR auto-merges end-to-end.